### PR TITLE
Don't start IPFS (start in offline mode)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -43,7 +43,7 @@ const argv = require('yargs')
       ipfs = new IPFS(nodeAddress.address, nodeAddress.port)
     } else {
       const IPFS = require('ipfs')
-      ipfs = await IPFS.create()
+      ipfs = await IPFS.create({ start: false })
     }
   } catch (e) {
     console.error(e)
@@ -67,9 +67,5 @@ const argv = require('yargs')
   }
 
   process.stdout.write(result + '\n')
-
-  if (!argv['ipfs-api']) {
-    await ipfs.stop()
-    process.exit(0)
-  }
+  process.exit(0)
 })(argv)


### PR DESCRIPTION
This PR changes the IPFS init so that IPFS is not started (and starts in offline mode). This speeds up the startup time for IPFs and `ambc`.